### PR TITLE
added error control flow seems like its working

### DIFF
--- a/ESP32_battery_charger/include/constants.h
+++ b/ESP32_battery_charger/include/constants.h
@@ -13,13 +13,14 @@ constexpr const char *PASSWORD = "12345678";
 constexpr int SERIAL_BAUD_RATE = 115200;
 
 // ----------JSON KEY STRINGS----------
-constexpr const char *CHARGING_TIME = "chargingTime";
+constexpr const char *CHARGING_TIME_KEY = "chargingTime";
 constexpr const char *IS_CHARGING = "isCharging";
 constexpr const char *CURR_TIME = "currTime";
 
 // ----------TIME MILLIS CONSTANTS----------
 constexpr int INTERVAL_60S_MILLIS = 60000;
 constexpr int INTERVAL_10S_MILLIS = 10000;
+constexpr int INTERVAL_5S_MILLIS = 5000;
 constexpr int INTERVAL_GET_DATA_FROM_SERVER = 1 * INTERVAL_10S_MILLIS;
 constexpr int INTERVAL_GET_TIME_FROM_SERVER = 1 * INTERVAL_10S_MILLIS;
 constexpr int INTERVAL_15MIN_MILLIS = 15 * INTERVAL_10S_MILLIS;
@@ -35,6 +36,9 @@ constexpr int SYNC_SERVER_0600_IDX = 24;
 constexpr int SYNC_SERVER_1200_IDX = 48;
 constexpr int SYNC_SERVER_1715_IDX = 69;
 constexpr int SYNC_SERVER_2200_IDX = 88;
+
+// ----------ERROR CONTROL FLOW CONSTANTS----------
+constexpr int RETRY_NBR = 5;
 
 // ----------DATA SIZE CONSTANTS----------
 constexpr int ARR_LEN = 96;

--- a/ESP32_battery_charger/include/error_constants.h
+++ b/ESP32_battery_charger/include/error_constants.h
@@ -8,7 +8,9 @@ constexpr const int ERROR_DEST_SIZE_TO_SMALL = 3;
 constexpr const int ERROR_DESERIALIZE_JSON = 4;
 constexpr const int ERROR_RECV_TIME_TOO_SMALL = 5;
 constexpr const int ERROR_EXCEEDED_WAIT_TIME_FOR_DATA_FROM_SERVER = 6;
-
+constexpr const int ERROR_GET_FAILED = 7;
+constexpr const int ERROR_GET_COULDNT_RECV_DATA = 8;
+constexpr const int ERROR_GET_UNABLE_TO_CONNECT = 9;
 
 
 #endif // ERROR_CONSTANTS_H

--- a/ESP32_battery_charger/lib/char_utils/char_arr_utils.cpp
+++ b/ESP32_battery_charger/lib/char_utils/char_arr_utils.cpp
@@ -5,10 +5,11 @@
 /**
  * We assume each src char array is null-terminated, and given char arr len 
  * is in fact it's length. Otherwise, undefined behavior will occur.
+ * --> src arr is appended to dest arr.
  * 
- * When len(src) > dest_size we clear dest and return error
- * 
- * src arr is appended to dest arr.
+ * Returns:
+ * - ERROR_DEST_SIZE_TO_SMALL - when src1 + src2 too long for char dest[]
+ * - SUCCESS - otherwise
  */
 int CharArrUtils::concat_char_arr(char dest[],
                                   const char *src1,

--- a/ESP32_battery_charger/lib/http_handler/http_handler.h
+++ b/ESP32_battery_charger/lib/http_handler/http_handler.h
@@ -13,7 +13,6 @@ public:
     int get_charging_data(int charging_times_arr[],
                             int arr_len,
                             const char *charging_time_key, 
-                            const char *is_charging_key,
                             const char *server_name, 
                             const char *endpoint_name);
 
@@ -28,7 +27,7 @@ public:
 
 private:
     // CLASS CONSTANTS
-    static constexpr const int SERVER_ENDPOINT_MAX_LEN = 100;
+    static constexpr const int SERVER_ENDPOINT_MAX_LEN = 1024;
     static constexpr const int RECV_BUFF_SIZE = 1024;
 
     // CLASS MEMBER VARIABLES

--- a/ESP32_battery_charger/lib/recv_functions/recv_func.cpp
+++ b/ESP32_battery_charger/lib/recv_functions/recv_func.cpp
@@ -40,13 +40,12 @@ int recv_curr_interval(int *curr_charging_interval_idx,
 int recv_charging_data(int charging_times_arr[],
                         HttpHandler &http_handler)
 {
+  Serial.println("RECV_CHARGING_DATA");
   int ret_code = http_handler.get_charging_data(charging_times_arr,
                                                 NBR_OF_INTERVALS,
-                                                CHARGING_TIME,
-                                                IS_CHARGING,
+                                                CHARGING_TIME_KEY,
                                                 SERVER_ADDRESS,
                                                 CHARGING_DATA_ENDPOINT);
-  Serial.println("RECV_CHARGING_DATA");
   if (ret_code == SUCCESS)
   {
     Serial.println("###SUCCESS - data received###\nPrinting data:");
@@ -64,36 +63,96 @@ int recv_charging_data(int charging_times_arr[],
 }
 
 
-// HELPER FUNCTIONS
+// -------- HELPER FUNCTIONS --------
+
+// int handle_error_ret_code(int ret_code)
+// {
+//   // TODO
+//   // We probably need to set some flags here so that in main we can handle them
+//   switch (ret_code)
+//   {
+//   // ######### TODO #########
+//   // Errors need some handlers, e.g. like while we dont get success we send
+//   // like 10 consecutive gets to server in 10s intervals, and if we still
+//   // dont get success, we send info about it to server and maybe wait for
+//   // its response etc.
+//   case ERROR:
+//     Serial.println("[main] Normal error");
+//     break;
+//   case ERROR_MORE_DATA_THAN_BUFF_SIZE:
+//     Serial.println("[main] More data than buff size error");
+//     break;
+//   case ERROR_DEST_SIZE_TO_SMALL:
+//     Serial.println("[main] Dest size to small");
+//     break;
+//   case ERROR_DESERIALIZE_JSON:
+//     Serial.println("[main] Deserialize json");
+//     break;
+//   case ERROR_RECV_TIME_TOO_SMALL:
+//     Serial.println("[main] REcv time too small");
+//     break;
+//   default:
+//     Serial.println("[main] Unknown error");
+//     break;
+//   }
+//   return ERROR;
+// }
+
+/**
+ * If we get any error it means we have already retried to fetch data from
+ * server RETRY_NBR of times, since we failed we also know that data we gave
+ * to fetch functions WAS NOT CHANGED thus here we only print logging info
+ * and in main function we continue code execution with old data
+ */
 int handle_error_ret_code(int ret_code)
 {
-  // TODO
-  // We probably need to set some flags here so that in main we can handle them
-  switch (ret_code)
-  {
-  // ######### TODO #########
-  // Errors need some handlers, e.g. like while we dont get success we send
-  // like 10 consecutive gets to server in 10s intervals, and if we still
-  // dont get success, we send info about it to server and maybe wait for
-  // its response etc.
-  case ERROR:
-    Serial.println("[main] Normal error");
-    break;
-  case ERROR_MORE_DATA_THAN_BUFF_SIZE:
-    Serial.println("[main] More data than buff size error");
-    break;
-  case ERROR_DEST_SIZE_TO_SMALL:
-    Serial.println("[main] Dest size to small");
-    break;
-  case ERROR_DESERIALIZE_JSON:
-    Serial.println("[main] Deserialize json");
-    break;
-  case ERROR_RECV_TIME_TOO_SMALL:
-    Serial.println("[main] REcv time too small");
-    break;
-  default:
-    Serial.println("[main] Unknown error");
-    break;
-  }
-  return ERROR;
+    switch (ret_code)
+    {
+    case SUCCESS:
+        Serial.println("[main] No error, operation successful");
+        return SUCCESS;
+
+    case ERROR:
+        Serial.println("[main] General error occurred");
+        break;
+
+    case ERROR_MORE_DATA_THAN_BUFF_SIZE:
+        Serial.println("[main] Error: More data than buffer size");
+        break;
+
+    case ERROR_DEST_SIZE_TO_SMALL:
+        Serial.println("[main] Error: Destination size too small");
+        break;
+
+    case ERROR_DESERIALIZE_JSON:
+        Serial.println("[main] Error: Failed to deserialize JSON");
+        break;
+
+    case ERROR_RECV_TIME_TOO_SMALL:
+        Serial.println("[main] Error: Received time too small");
+        break;
+
+    case ERROR_EXCEEDED_WAIT_TIME_FOR_DATA_FROM_SERVER:
+        Serial.println("[main] Error: Exceeded wait time for data from server");
+        break;
+
+    case ERROR_GET_FAILED:
+        Serial.println("[main] Error: HTTP GET request failed");
+        break;
+
+    case ERROR_GET_COULDNT_RECV_DATA:
+        Serial.println("[main] Error: Couldn't receive data from server");
+        break;
+
+    case ERROR_GET_UNABLE_TO_CONNECT:
+        Serial.println("[main] Error: Unable to connect to server");
+        break;
+
+    default:
+        Serial.printf("[main] Unknown error code: %d\n", ret_code);
+        break;
+    }
+
+    // Return the error code for further handling if needed
+    return ret_code;
 }

--- a/fastAPI_server/server.py
+++ b/fastAPI_server/server.py
@@ -15,6 +15,11 @@ async def root():
     print(f"Byte size of JSON data: {byte_size}")
     # print(f"json_data {json_data}")
 
+     # Pretty print the charging data
+    print("Charging Data (idx: value):")
+    for idx, value in enumerate(json_data["chargingTime"]):
+        print(f"{idx}: {value}")
+
     return  json_data
 
 
@@ -27,6 +32,6 @@ async def get_curr_time():
 
     # Minutes until the next interval
     minutes_till_next_interval = 15 - (total_minutes % 15)  
-    print(f"#### currIntervalIdx {curr_interval_idx}, minutesTillNext {minutes_till_next_interval}####")
+    print(f"#### currIntervalIdx {curr_interval_idx}, minutesTillNext {minutes_till_next_interval}, curr_time: {now}####")
     return {"currIntervalIdx": curr_interval_idx,
             "minutesTillNextInterval": minutes_till_next_interval}


### PR DESCRIPTION
- when we fail to fetch data in get_data() func we repeat fetching data for RETRY_NBR times, than if
still unsuccessful we propagate error further
- in main func in handle_battery_turn_on_off if we encounter error, (our fetch functions do not change data if error encountered) we simply continue programme with data we currently have and will fetch new data in next SYNC POINT
- this flow works only for NOT FIRST data fetch, if first data fetch fails we try to fetch data as long as it's needed